### PR TITLE
Add PDF assistant bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+pdfs/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# PDF Assistant Bot
+
+This project provides a simple Flask web app that loads PDF files, indexes them using OpenAI embeddings and FAISS, and answers user questions. The web UI can be embedded in another site via an iframe.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Place your training PDFs inside a folder named `pdfs/` in the project root (or specify another path with the `PDF_DIR` environment variable).
+
+3. Export your OpenAI API key:
+
+```bash
+export OPENAI_API_KEY=your_key
+```
+
+4. Run the server:
+
+```bash
+python -m pdf_bot.app
+```
+
+The app will be available on `http://localhost:5000` and can be embedded in an `<iframe>`.

--- a/pdf_bot/app.py
+++ b/pdf_bot/app.py
@@ -1,0 +1,42 @@
+import os
+from flask import Flask, request, jsonify, render_template
+import openai
+
+from .pdf_processor import PdfVectorIndex
+
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+PDF_DIR = os.getenv("PDF_DIR", "pdfs")
+
+app = Flask(__name__)
+vector_index = PdfVectorIndex(OPENAI_API_KEY)
+vector_index.build_index(PDF_DIR)
+
+
+def generate_answer(question: str) -> str:
+    contexts = vector_index.query(question)
+    prompt = "Answer the question using the context below.\n\n" + "\n\n".join(contexts) + f"\n\nQuestion: {question}\nAnswer:"
+    response = openai.chat.completions.create(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.2,
+    )
+    return response.choices[0].message.content.strip()
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/ask", methods=["POST"])
+def ask():
+    data = request.get_json()
+    question = data.get("question", "")
+    if not question:
+        return jsonify({"error": "Question is required"}), 400
+    answer = generate_answer(question)
+    return jsonify({"answer": answer})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/pdf_bot/pdf_processor.py
+++ b/pdf_bot/pdf_processor.py
@@ -1,0 +1,63 @@
+import os
+from typing import List, Tuple
+
+import openai
+import numpy as np
+from PyPDF2 import PdfReader
+import faiss
+
+
+def load_pdf_text(pdf_path: str) -> str:
+    """Extract text from a single PDF file."""
+    reader = PdfReader(pdf_path)
+    text = ""
+    for page in reader.pages:
+        text += page.extract_text() or ""
+    return text
+
+
+def split_text(text: str, chunk_size: int = 500, overlap: int = 50) -> List[str]:
+    """Split text into overlapping chunks."""
+    words = text.split()
+    chunks = []
+    start = 0
+    while start < len(words):
+        end = start + chunk_size
+        chunk = " ".join(words[start:end])
+        chunks.append(chunk)
+        start += chunk_size - overlap
+    return chunks
+
+
+class PdfVectorIndex:
+    def __init__(self, openai_api_key: str):
+        openai.api_key = openai_api_key
+        self.index = None
+        self.text_chunks: List[str] = []
+
+    def build_index(self, pdf_dir: str):
+        """Load PDFs from a directory and build FAISS index."""
+        all_chunks = []
+        for fname in os.listdir(pdf_dir):
+            if fname.lower().endswith(".pdf"):
+                text = load_pdf_text(os.path.join(pdf_dir, fname))
+                chunks = split_text(text)
+                all_chunks.extend(chunks)
+        self.text_chunks = all_chunks
+        embeddings = self._embed_texts(all_chunks)
+        dim = embeddings.shape[1]
+        self.index = faiss.IndexFlatL2(dim)
+        self.index.add(embeddings)
+
+    def _embed_texts(self, texts: List[str]) -> np.ndarray:
+        embeddings = []
+        for text in texts:
+            resp = openai.embeddings.create(input=[text], model="text-embedding-ada-002")
+            embeddings.append(np.array(resp.data[0].embedding, dtype=np.float32))
+        return np.vstack(embeddings)
+
+    def query(self, question: str, top_k: int = 3) -> List[str]:
+        q_resp = openai.embeddings.create(input=[question], model="text-embedding-ada-002")
+        q_emb = np.array(q_resp.data[0].embedding, dtype=np.float32).reshape(1, -1)
+        distances, indices = self.index.search(q_emb, top_k)
+        return [self.text_chunks[i] for i in indices[0]]

--- a/pdf_bot/templates/index.html
+++ b/pdf_bot/templates/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>PDF Assistant</title>
+  <style>
+    body { font-family: Arial, sans-serif; }
+    #chat { max-width: 600px; margin: 20px auto; }
+    .message { padding: 10px; margin-bottom: 5px; border-radius: 5px; }
+    .user { background: #eef; }
+    .bot { background: #efe; }
+  </style>
+</head>
+<body>
+<div id="chat">
+  <div id="messages"></div>
+  <form id="question-form">
+    <input type="text" id="question" placeholder="Ask a question" size="60" required>
+    <button type="submit">Send</button>
+  </form>
+</div>
+<script>
+async function sendQuestion(question) {
+  const res = await fetch('/ask', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ question })
+  });
+  const data = await res.json();
+  return data.answer;
+}
+
+document.getElementById('question-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const qInput = document.getElementById('question');
+  const question = qInput.value;
+  qInput.value = '';
+  const messages = document.getElementById('messages');
+  messages.innerHTML += `<div class="message user">${question}</div>`;
+  const answer = await sendQuestion(question);
+  messages.innerHTML += `<div class="message bot">${answer}</div>`;
+});
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+openai
+PyPDF2
+faiss-cpu


### PR DESCRIPTION
## Summary
- add a Flask-based app to load PDF data and answer questions via OpenAI
- index PDFs with embeddings using faiss
- provide simple HTML chat interface for embedding in iframes
- document setup steps
- add requirements and gitignore

## Testing
- `pip install openai flask pypdf2 faiss-cpu --quiet`
- `OPENAI_API_KEY=dummy PDF_DIR=pdfs python -m pdf_bot.app` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'pdfs')*

------
https://chatgpt.com/codex/tasks/task_e_68567ecae5ec8329a9d51939c4bb6444