### PR TITLE
Add persistent FAISS index and PDF upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ python -m pdf_bot.app
 
 The app will be available on `http://localhost:5000` and can be embedded in an `<iframe>`.
 
+The FAISS index and text chunks are saved to `index.faiss` and `chunks.json` by default so embeddings persist across restarts. Use the `INDEX_PATH` and `CHUNKS_PATH` environment variables to change these locations.
+
+You can upload new PDF files through the web interface or by sending a `POST` request with a `file` field to `/upload`. Uploaded PDFs are immediately indexed and saved.
+
 ## UI Features
 
 The chat interface mimics a messenger-style layout. It automatically scrolls to

--- a/pdf_bot/pdf_processor.py
+++ b/pdf_bot/pdf_processor.py
@@ -1,4 +1,5 @@
 import os
+import json
 from typing import List, Tuple
 
 import openai
@@ -30,24 +31,61 @@ def split_text(text: str, chunk_size: int = 500, overlap: int = 50) -> List[str]
 
 
 class PdfVectorIndex:
-    def __init__(self, openai_api_key: str):
+    def __init__(self, openai_api_key: str, index_path: str, chunks_path: str):
         openai.api_key = openai_api_key
+        self.index_path = index_path
+        self.chunks_path = chunks_path
         self.index = None
         self.text_chunks: List[str] = []
 
+    def load_index(self) -> bool:
+        """Load index and text chunks from disk if available."""
+        if os.path.exists(self.index_path) and os.path.exists(self.chunks_path):
+            self.index = faiss.read_index(self.index_path)
+            with open(self.chunks_path, "r", encoding="utf-8") as f:
+                self.text_chunks = json.load(f)
+            return True
+        return False
+
+    def save_index(self) -> None:
+        """Persist index and text chunks to disk."""
+        if self.index is not None:
+            faiss.write_index(self.index, self.index_path)
+            with open(self.chunks_path, "w", encoding="utf-8") as f:
+                json.dump(self.text_chunks, f)
+
     def build_index(self, pdf_dir: str):
-        """Load PDFs from a directory and build FAISS index."""
-        all_chunks = []
-        for fname in os.listdir(pdf_dir):
-            if fname.lower().endswith(".pdf"):
-                text = load_pdf_text(os.path.join(pdf_dir, fname))
-                chunks = split_text(text)
-                all_chunks.extend(chunks)
-        self.text_chunks = all_chunks
-        embeddings = self._embed_texts(all_chunks)
-        dim = embeddings.shape[1]
-        self.index = faiss.IndexFlatL2(dim)
+        """Load PDFs from a directory and build or load FAISS index."""
+        if self.load_index():
+            return
+
+        pdf_paths = [
+            os.path.join(pdf_dir, f)
+            for f in os.listdir(pdf_dir)
+            if f.lower().endswith(".pdf")
+        ]
+        self.add_pdfs(pdf_paths, save=False)
+        self.save_index()
+
+    def add_pdfs(self, pdf_paths: List[str], save: bool = True) -> None:
+        """Add PDF files to the index."""
+        new_chunks = []
+        for path in pdf_paths:
+            if not os.path.exists(path):
+                continue
+            text = load_pdf_text(path)
+            chunks = split_text(text)
+            new_chunks.extend(chunks)
+        if not new_chunks:
+            return
+        embeddings = self._embed_texts(new_chunks)
+        if self.index is None:
+            dim = embeddings.shape[1]
+            self.index = faiss.IndexFlatL2(dim)
         self.index.add(embeddings)
+        self.text_chunks.extend(new_chunks)
+        if save:
+            self.save_index()
 
     def _embed_texts(self, texts: List[str]) -> np.ndarray:
         embeddings = []

--- a/pdf_bot/templates/index.html
+++ b/pdf_bot/templates/index.html
@@ -91,6 +91,10 @@
 <div id="chat">
   <div id="remaining">Questions left: 7</div>
   <div id="error"></div>
+  <form id="upload-form" style="margin-bottom:10px;">
+    <input type="file" id="pdfFile" accept="application/pdf" required>
+    <button type="submit">Upload PDF</button>
+  </form>
   <div id="messages"></div>
   <form id="question-form">
     <input type="text" id="question" placeholder="Ask a question" size="60" required>
@@ -117,6 +121,26 @@ async function sendQuestion(question) {
   remaining = data.remaining;
   return data.answer;
 }
+
+document.getElementById('upload-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const fileInput = document.getElementById('pdfFile');
+  const file = fileInput.files[0];
+  if (!file) return;
+  const formData = new FormData();
+  formData.append('file', file);
+  const errorDiv = document.getElementById('error');
+  errorDiv.textContent = '';
+  try {
+    const res = await fetch('/upload', { method: 'POST', body: formData });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Upload failed');
+    errorDiv.textContent = 'Upload successful';
+    fileInput.value = '';
+  } catch (err) {
+    errorDiv.textContent = err.message;
+  }
+});
 
 document.getElementById('question-form').addEventListener('submit', async (e) => {
   e.preventDefault();


### PR DESCRIPTION
## Summary
- save embeddings and index to disk using new `INDEX_PATH` and `CHUNKS_PATH`
- load the saved index on startup
- allow uploading new PDF files from the web UI and `/upload` endpoint
- document persistent index and upload feature

## Testing
- `python -m py_compile pdf_bot/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6856e576e2b083298aabbc527c0a7975