### PR TITLE
Remove file upload capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ The app will be available on `http://localhost:5000` and can be embedded in an `
 
 The FAISS index and text chunks are saved to `index.faiss` and `chunks.json` by default so embeddings persist across restarts. Use the `INDEX_PATH` and `CHUNKS_PATH` environment variables to change these locations.
 
-You can upload new PDF files through the web interface or by sending a `POST` request with a `file` field to `/upload`. Uploaded PDFs are immediately indexed and saved.
-
 ## UI Features
 
 The chat interface mimics a messenger-style layout. It automatically scrolls to

--- a/pdf_bot/app.py
+++ b/pdf_bot/app.py
@@ -14,7 +14,6 @@ app.secret_key = os.getenv("FLASK_SECRET_KEY", "please-change-me")
 vector_index = PdfVectorIndex(OPENAI_API_KEY, INDEX_PATH, CHUNKS_PATH)
 vector_index.build_index(PDF_DIR)
 
-
 def generate_answer(question: str) -> str:
     contexts = vector_index.query(question)
     prompt = (
@@ -49,23 +48,6 @@ def ask():
     answer = generate_answer(question)
     remaining = 7 - session["question_count"]
     return jsonify({"answer": answer, "remaining": remaining})
-
-
-@app.route("/upload", methods=["POST"])
-def upload_pdf():
-    if "file" not in request.files:
-        return jsonify({"error": "No file"}), 400
-    file = request.files["file"]
-    if file.filename == "":
-        return jsonify({"error": "No selected file"}), 400
-    if not file.filename.lower().endswith(".pdf"):
-        return jsonify({"error": "Invalid file type"}), 400
-    os.makedirs(PDF_DIR, exist_ok=True)
-    path = os.path.join(PDF_DIR, file.filename)
-    file.save(path)
-    vector_index.add_pdfs([path])
-    return jsonify({"status": "uploaded"})
-
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)

--- a/pdf_bot/templates/index.html
+++ b/pdf_bot/templates/index.html
@@ -91,10 +91,6 @@
 <div id="chat">
   <div id="remaining">Questions left: 7</div>
   <div id="error"></div>
-  <form id="upload-form" style="margin-bottom:10px;">
-    <input type="file" id="pdfFile" accept="application/pdf" required>
-    <button type="submit">Upload PDF</button>
-  </form>
   <div id="messages"></div>
   <form id="question-form">
     <input type="text" id="question" placeholder="Ask a question" size="60" required>
@@ -122,25 +118,6 @@ async function sendQuestion(question) {
   return data.answer;
 }
 
-document.getElementById('upload-form').addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const fileInput = document.getElementById('pdfFile');
-  const file = fileInput.files[0];
-  if (!file) return;
-  const formData = new FormData();
-  formData.append('file', file);
-  const errorDiv = document.getElementById('error');
-  errorDiv.textContent = '';
-  try {
-    const res = await fetch('/upload', { method: 'POST', body: formData });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.error || 'Upload failed');
-    errorDiv.textContent = 'Upload successful';
-    fileInput.value = '';
-  } catch (err) {
-    errorDiv.textContent = err.message;
-  }
-});
 
 document.getElementById('question-form').addEventListener('submit', async (e) => {
   e.preventDefault();


### PR DESCRIPTION
## Summary
- remove `/upload` route from pdf bot
- strip upload form and JS from pdf bot UI
- delete upload instructions from README

## Testing
- `python -m py_compile pdf_bot/app.py pdf_bot/pdf_processor.py`

------
https://chatgpt.com/codex/tasks/task_e_6857f2f3958083299b5f0eb650ae4d95