### PR TITLE
Add embeddable chat widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ python -m pdf_bot.app
 
 The app will be available on `http://localhost:5000` and can be embedded in an `<iframe>`.
 
+### Embedding Example
+
+To embed the chat widget on another website, point an `<iframe>` to the `/widget` route of your running server:
+
+```html
+<iframe src="http://localhost:5000/widget" width="420" height="600" style="border:0"></iframe>
+```
+
 The FAISS index and text chunks are saved to `index.faiss` and `chunks.json` by default so embeddings persist across restarts. Use the `INDEX_PATH` and `CHUNKS_PATH` environment variables to change these locations.
 
 You can upload new PDF files through the web interface or by sending a `POST` request with a `file` field to `/upload`. Uploaded PDFs are immediately indexed and saved.

--- a/pdf_bot/app.py
+++ b/pdf_bot/app.py
@@ -36,6 +36,12 @@ def index():
     return render_template("index.html")
 
 
+@app.route("/widget")
+def widget():
+    """Return minimal chat UI for embedding."""
+    return render_template("widget.html")
+
+
 @app.route("/ask", methods=["POST"])
 def ask():
     data = request.get_json()

--- a/pdf_bot/templates/widget.html
+++ b/pdf_bot/templates/widget.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>PDF Assistant</title>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+      font-family: Arial, sans-serif;
+      background: #f5f5f5;
+    }
+    #chat {
+      width: 100%;
+      height: 100%;
+      background: #fff;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      padding: 20px;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      display: flex;
+      flex-direction: column;
+    }
+    #messages {
+      flex: 1;
+      overflow-y: auto;
+      margin-bottom: 10px;
+      display: flex;
+      flex-direction: column;
+    }
+    .message {
+      max-width: 80%;
+      padding: 8px 12px;
+      margin-bottom: 8px;
+      border-radius: 18px;
+      word-wrap: break-word;
+      overflow-wrap: anywhere;
+    }
+    .user {
+      background: #0084ff;
+      color: #fff;
+      align-self: flex-end;
+      border-bottom-right-radius: 2px;
+    }
+    .bot {
+      background: #e5e5ea;
+      align-self: flex-start;
+      border-bottom-left-radius: 2px;
+    }
+    @keyframes blink {
+      0% { opacity: 0.2; }
+      20% { opacity: 1; }
+      100% { opacity: 0.2; }
+    }
+    .typing {
+      font-style: italic;
+      opacity: 0.7;
+    }
+    .typing::after {
+      content: '...';
+      animation: blink 1s infinite steps(3, end);
+    }
+    #remaining {
+      font-size: 0.9em;
+      color: #666;
+      text-align: right;
+      margin-bottom: 10px;
+    }
+    #error {
+      color: red;
+      margin-bottom: 10px;
+    }
+    #question-form {
+      display: flex;
+    }
+    #question {
+      flex: 1;
+      padding: 8px;
+      font-size: 1em;
+    }
+    button {
+      padding: 8px 12px;
+      font-size: 1em;
+    }
+  </style>
+</head>
+<body>
+<div id="chat">
+  <div id="remaining">Questions left: 7</div>
+  <div id="error"></div>
+  <form id="upload-form" style="margin-bottom:10px;">
+    <input type="file" id="pdfFile" accept="application/pdf" required>
+    <button type="submit">Upload PDF</button>
+  </form>
+  <div id="messages"></div>
+  <form id="question-form">
+    <input type="text" id="question" placeholder="Ask a question" size="60" required>
+    <button type="submit">Send</button>
+  </form>
+</div>
+<script>
+let remaining = 7;
+function scrollToBottom() {
+  const messages = document.getElementById('messages');
+  messages.scrollTop = messages.scrollHeight;
+}
+
+async function sendQuestion(question) {
+  const res = await fetch('/ask', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ question })
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error || 'Error');
+  }
+  remaining = data.remaining;
+  return data.answer;
+}
+
+document.getElementById('upload-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const fileInput = document.getElementById('pdfFile');
+  const file = fileInput.files[0];
+  if (!file) return;
+  const formData = new FormData();
+  formData.append('file', file);
+  const errorDiv = document.getElementById('error');
+  errorDiv.textContent = '';
+  try {
+    const res = await fetch('/upload', { method: 'POST', body: formData });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Upload failed');
+    errorDiv.textContent = 'Upload successful';
+    fileInput.value = '';
+  } catch (err) {
+    errorDiv.textContent = err.message;
+  }
+});
+
+document.getElementById('question-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const qInput = document.getElementById('question');
+  const question = qInput.value.trim();
+  if (!question) return;
+  qInput.value = '';
+  qInput.focus();
+  const messages = document.getElementById('messages');
+  const errorDiv = document.getElementById('error');
+  errorDiv.textContent = '';
+
+  const userDiv = document.createElement('div');
+  userDiv.className = 'message user';
+  userDiv.textContent = question;
+  messages.appendChild(userDiv);
+  scrollToBottom();
+
+  const typingDiv = document.createElement('div');
+  typingDiv.className = 'message bot typing';
+  typingDiv.textContent = 'Bot is typing';
+  messages.appendChild(typingDiv);
+  scrollToBottom();
+
+  try {
+    const answer = await sendQuestion(question);
+    typingDiv.textContent = answer;
+    typingDiv.classList.remove('typing');
+    document.getElementById('remaining').textContent = `Questions left: ${remaining}`;
+    if (remaining <= 0) {
+      qInput.disabled = true;
+      errorDiv.textContent = 'Question limit reached';
+    }
+  } catch (err) {
+    messages.removeChild(typingDiv);
+    errorDiv.textContent = err.message;
+  }
+  scrollToBottom();
+  if (!qInput.disabled) qInput.focus();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `widget.html` with layout suited for iframes
- serve new page from `/widget`
- document how to embed the chat widget

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857f455e9548329b2aee510d697efa9